### PR TITLE
Made the zeroes a bit more clean and user friendly

### DIFF
--- a/app/components/window-order-form/fields-generic/NumberDollarsField.tsx
+++ b/app/components/window-order-form/fields-generic/NumberDollarsField.tsx
@@ -17,8 +17,8 @@ export function NumberDollarsField({
       <input
         type="number"
         className="w-full p-2 border rounded mb-3"
-        value={value ?? 0}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
+        value={value && value !== 0 ? value : ''}
+        onChange={(e) => onChange(e.target.value === '' ? 0 : parseFloat(e.target.value) || 0)}
         step="0.01"
         min="0"
       />

--- a/app/components/window-order-form/fields-generic/NumberInchesField.tsx
+++ b/app/components/window-order-form/fields-generic/NumberInchesField.tsx
@@ -54,11 +54,8 @@ export function NumberInchesField({
 
   const handleWholeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value;
-    console.log('handleWholeChange'+input)
-    const newVal = parseInt(input, 10);
-    console.log('handleWholeChange'+newVal)
+    const newVal = input === '' ? 0 : parseInt(input, 10);
     const safeVal = isNaN(newVal) ? 0 : newVal;
-    console.log('handleWholeChange'+safeVal)
 
     setFullInches(safeVal);
     updateInches(safeVal, fraction);
@@ -107,7 +104,7 @@ function simplifyFraction(numerator: number, denominator: number): {
         <input
           type='text'
           className="flex-1 p-2 border rounded"
-          value={fullInches}
+          value={fullInches === 0 ? '' : fullInches}
           onChange={handleWholeChange}
           placeholder="0"
         />


### PR DESCRIPTION
The UI now shows an empty input field when the value is zero, making it clearer that no measurement has been entered, while still maintaining the internal zero value to prevent null errors.

